### PR TITLE
Specify the role name in the galaxy metadata file

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
 galaxy_info:
+  role_name: deploy-archive
   author: ome-devel@lists.openmicroscopy.org.uk
   description: Download and deploy an archive
   company: Open Microscopy Environment


### PR DESCRIPTION
This feature used to be at the UI level but is now read from the configuration
since Galaxy v3.0 - see https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names

NB: unclear whether all our roles will need to be patched or existing renamed roles will keep being updated