### PR TITLE
Set default serole setype seuser on dest dir

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,9 @@
     path: "{{ deploy_archive_dest_dir }}"
     recurse: yes
     state: directory
+    serole: _default
+    setype: _default
+    seuser: _default
 
 - name: deploy archive | download
   get_url:


### PR DESCRIPTION
The old jekyll-role set default selinux parameters on the destination directory which is read by Nginx: https://github.com/openmicroscopy/ansible-role-jekyll-build/blob/0294ad939d2435f776f75547fe902522ba5e21ad/tasks/main.yml#L55-L57

This was missing from deploy-archive.

Tag: `0.1.2`