### PR TITLE
Do everything as root

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for deploy-archive
 
 - name: deploy archive | create directory
+  become: true
   file:
     path: "{{ deploy_archive_dest_dir }}"
     state: directory
@@ -11,6 +12,7 @@
     mode: 0755
 
 - name: deploy archive | download
+  become: true
   get_url:
     url: "{{ deploy_archive_src_url }}"
     checksum: >-
@@ -19,6 +21,7 @@
     dest: "{{ deploy_archive_dest_dir }}/{{ deploy_archive_filename }}"
 
 - name: deploy archive | unarchive
+  become: true
   unarchive:
     src: "{{ deploy_archive_dest_dir }}/{{ deploy_archive_filename }}"
     dest: "{{ deploy_archive_dest_dir }}"
@@ -27,6 +30,7 @@
     remote_src: true
 
 - name: deploy archive | create symlink parent directory
+  become: true
   file:
     path: "{{ deploy_archive_symlink | dirname }}"
     state: directory
@@ -34,6 +38,7 @@
   when: deploy_archive_symlink | dirname | length > 0
 
 - name: deploy archive | symlink
+  become: true
   file:
     path: "{{ deploy_archive_symlink }}"
     src: "{{ deploy_archive_dest_dir }}/{{ deploy_archive_internal_root }}"


### PR DESCRIPTION
When running the playbook to create a rocky9 pilot, I got:
```
TASK [ome.deploy_archive : deploy archive | download] ******************************************************************************************************************************
fatal: [2f5d1f82-2aad-433b-ab9f-98c5fe25ffa5]: FAILED! => {"changed": false, "checksum_dest": null, "checksum_src": "a62fbc182e289c631d1ed3b92f89a4327e9673d4", "dest": "/opt/Ice-3.6.5-rhel9-x86_64.tar.gz", "elapsed": 1, "msg": "Destination /opt is not writable", "src": "/home/rocky/.ansible/tmp/ansible-tmp-1709728764.179449-27092-97387295984443/tmpod0r75si", "url": "https://github.com/glencoesoftware/zeroc-ice-rhel9-x86_64/releases/download/20231130/Ice-3.6.5-rhel9-x86_64.tar.gz"}
```

This PR fixes the issue. I know it failed on task `deploy archive | download`, but I added `become: true` to the other tasks as well. It looks like they're all doing something in `/opt` which is not writable by the rocky user.
